### PR TITLE
Upgrade NPOI from 2.6.0 to 2.7.5

### DIFF
--- a/NPOIHelpers/NPOIHelpers.csproj
+++ b/NPOIHelpers/NPOIHelpers.csproj
@@ -53,7 +53,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NPOI">
-      <Version>2.6.0</Version>
+      <Version>2.7.5</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -53,7 +53,7 @@
       <Version>3.0.2</Version>
     </PackageReference>
     <PackageReference Include="NPOI">
-      <Version>2.6.0</Version>
+      <Version>2.7.5</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Upgrades NPOI package from 2.6.0 to 2.7.5 in both projects

## Changes
- `NPOIHelpers/NPOIHelpers.csproj`: NPOI 2.6.0 → 2.7.5
- `Tests/Tests.csproj`: NPOI 2.6.0 → 2.7.5

## Test plan
- [x] Solution builds successfully
- [x] Unit tests pass (2/2 tests that don't require external files)

Closes #1