### PR TITLE
Add test data generator and fix test file references

### DIFF
--- a/Tests/App.config
+++ b/Tests/App.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/TestDataGenerator.cs
+++ b/Tests/TestDataGenerator.cs
@@ -1,0 +1,79 @@
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+using System.IO;
+
+namespace Tests
+{
+  public static class TestDataGenerator
+  {
+    public static readonly string TestDataPath = Path.Combine(
+      Path.GetDirectoryName(typeof(TestDataGenerator).Assembly.Location),
+      "TestData");
+
+    public static string BigTestPath => Path.Combine(TestDataPath, "bigtest.xlsx");
+    public static string BigTest1Path => Path.Combine(TestDataPath, "bigtest1.xlsx");
+
+    public static void EnsureTestDataExists()
+    {
+      Directory.CreateDirectory(TestDataPath);
+
+      if (!File.Exists(BigTestPath))
+        CreateBigTest();
+
+      if (!File.Exists(BigTest1Path))
+        CreateBigTest1();
+    }
+
+    private static void CreateBigTest()
+    {
+      var wb = new XSSFWorkbook();
+      var sheet = wb.CreateSheet("Sheet1");
+
+      for (int r = 0; r < 10000; r++)
+      {
+        var row = sheet.CreateRow(r);
+        for (int c = 0; c < 20; c++)
+        {
+          var cell = row.CreateCell(c);
+          cell.SetCellValue($"Cell: Row-{r};CellNo:{c}");
+        }
+      }
+
+      using (var fs = new FileStream(BigTestPath, FileMode.Create, FileAccess.Write))
+      {
+        wb.Write(fs);
+      }
+      wb.Close();
+    }
+
+    private static void CreateBigTest1()
+    {
+      var wb = new XSSFWorkbook();
+      var sheet = wb.CreateSheet("Sheet1");
+
+      // Row 0: blank cells at cols 0 and 19 to establish column range
+      var row0 = sheet.CreateRow(0);
+      row0.CreateCell(0).SetBlank();
+      row0.CreateCell(19).SetBlank();
+
+      // Rows 1-8: don't create (sparse)
+
+      // Rows 9-9999: cells at cols 5-19 with data
+      for (int r = 9; r < 10000; r++)
+      {
+        var row = sheet.CreateRow(r);
+        for (int c = 5; c < 20; c++)
+        {
+          var cell = row.CreateCell(c);
+          cell.SetCellValue($"Cell: Row-{r};CellNo:{c}");
+        }
+      }
+
+      using (var fs = new FileStream(BigTest1Path, FileMode.Create, FileAccess.Write))
+      {
+        wb.Write(fs);
+      }
+      wb.Close();
+    }
+  }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -10,6 +10,8 @@
     <RootNamespace>Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -42,7 +44,9 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <Compile Include="UnitTest1.cs" />
+    <Compile Include="TestDataGenerator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -54,6 +58,12 @@
     </PackageReference>
     <PackageReference Include="NPOI">
       <Version>2.7.5</Version>
+    </PackageReference>
+    <PackageReference Include="System.Memory">
+      <Version>4.5.5</Version>
+    </PackageReference>
+    <PackageReference Include="System.Collections.Immutable">
+      <Version>1.7.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/UnitTest1.cs
+++ b/Tests/UnitTest1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NPOI.SS.UserModel;
 using NPOI.SCIta.Helpers;
@@ -9,11 +9,16 @@ namespace Tests
   [TestClass]
   public class UnitTest1
   {
+    [ClassInitialize]
+    public static void ClassInit(TestContext context)
+    {
+      TestDataGenerator.EnsureTestDataExists();
+    }
 
     [TestMethod]
     public void TestGetUsedRangeAddress()
     {
-      var wb = WorkbookFactory.Create(@"k:\users\stefano\bigtest.xlsx");
+      var wb = WorkbookFactory.Create(TestDataGenerator.BigTestPath);
       var wh = wb.GetSheetAt(0);
       var u = wh.GetUsedRangeAddress();
       Assert.AreEqual(0, u.FirstRow);
@@ -48,7 +53,7 @@ namespace Tests
     [TestMethod]
     public void TestSheetGet11()
     {
-      var wb = WorkbookFactory.Create(@"k:\users\stefano\bigtest.xlsx");
+      var wb = WorkbookFactory.Create(TestDataGenerator.BigTestPath);
       var wh = wb.GetSheetAt(0);
       int rows = 3, cols = 4;
       int y = 1, x = 1;
@@ -70,7 +75,7 @@ namespace Tests
     [TestMethod]
     public void TestSheetGet22()
     {
-      var wb = WorkbookFactory.Create(@"k:\users\stefano\bigtest.xlsx");
+      var wb = WorkbookFactory.Create(TestDataGenerator.BigTestPath);
       var wh = wb.GetSheetAt(0);
       int rows = 3, cols = 4;
       int y = 2, x = 2;
@@ -90,7 +95,7 @@ namespace Tests
 
     public void TestSheetGet1_53()
     {
-      var wb = WorkbookFactory.Create(@"k:\users\stefano\bigtest1.xlsx");
+      var wb = WorkbookFactory.Create(TestDataGenerator.BigTest1Path);
       var wh = wb.GetSheetAt(0);
       int rows = 3;
       int cols = 4;
@@ -103,7 +108,7 @@ namespace Tests
     [TestMethod]
     public void TestSheetGet1_73()
     {
-      var wb = WorkbookFactory.Create(@"k:\users\stefano\bigtest1.xlsx");
+      var wb = WorkbookFactory.Create(TestDataGenerator.BigTest1Path);
       var wh = wb.GetSheetAt(0);
       int rows = 3, cols = 4;
       int y = 8, x = 3;
@@ -126,7 +131,7 @@ namespace Tests
     [TestMethod]
     public void TestSheetGet1_()
     {
-      var wb = WorkbookFactory.Create(@"k:\users\stefano\bigtest1.xlsx");
+      var wb = WorkbookFactory.Create(TestDataGenerator.BigTest1Path);
       var wh = wb.GetSheetAt(0);
       var r = wh.GetRange();
       Assert.AreEqual(10000, r.Values.GetLength(0));


### PR DESCRIPTION
## Summary
- Add TestDataGenerator.cs to create test Excel files on first run
- Update tests to use generated files instead of hardcoded paths
- Add App.config with assembly binding redirects
- Add System.Memory and System.Collections.Immutable packages

## Test plan
- [x] All 7 unit tests pass

Closes #3